### PR TITLE
Update to v0.0.9.2

### DIFF
--- a/com.github.quaternion.json
+++ b/com.github.quaternion.json
@@ -21,8 +21,8 @@
                 {
                     "type": "git",
                     "url": "git://github.com/QMatrixClient/Quaternion.git",
-                    "branch": "v0.0.5",
-                    "commit": "f6ae506c14acb223bdc196124efd4f35d6ffa2bb"
+                    "branch": "v0.0.9.2",
+                    "commit": "911bcd67ffc10ade8aeb7b89147b895dc800013e"
                 }
             ]
         }

--- a/com.github.quaternion.json
+++ b/com.github.quaternion.json
@@ -21,8 +21,8 @@
                 {
                     "type": "git",
                     "url": "git://github.com/QMatrixClient/Quaternion.git",
-                    "branch": "v0.0.9.2",
-                    "commit": "911bcd67ffc10ade8aeb7b89147b895dc800013e"
+                    "branch": "master",
+                    "commit": "cd43d805f39dd00f7cc178c40e8ba1d27bd84522"
                 }
             ]
         }


### PR DESCRIPTION
Update of Quaternion to v0.0.9.2
Due to #7 being seemingly dead I created this.

**THIS IS GOING TO FAIL**
The AppStream manifest is invalid, it is fixed in https://github.com/QMatrixClient/Quaternion/pull/361 due to this the v0.0.9.2 tag does not have the AppStream fixes.

cc: @KitsuneRal 