### PR TITLE
Update runtime and application

### DIFF
--- a/com.github.quaternion.json
+++ b/com.github.quaternion.json
@@ -2,7 +2,7 @@
     "id": "com.github.quaternion",
     "rename-icon": "quaternion",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.12",
+    "runtime-version": "5.15",
     "sdk": "org.kde.Sdk",
     "command": "quaternion",
     "finish-args": [
@@ -33,7 +33,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/quotient-im/Quaternion.git",
-                    "tag": "0.0.9.4e"
+                    "tag": "0.0.9.4f"
                 }
             ]
         }


### PR DESCRIPTION
This should be a painless update as this new release was made to run on newer Qt. It also changes to use newer OpenSSL which is definitely wanted, I think.

I didn't update libqmatrixclient because 0.6.x has breaking changes that I'm not sure are expected to work with Quaternion.