### PR TITLE
Patch appdata to point to the right desktop file

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -1,0 +1,13 @@
+diff --git a/linux/com.github.quaternion.appdata.xml b/linux/com.github.quaternion.appdata.xml
+index 84bca78..19d6446 100644
+--- a/linux/com.github.quaternion.appdata.xml
++++ b/linux/com.github.quaternion.appdata.xml
+@@ -19,7 +19,7 @@
+     <category>Network</category>
+   </categories>
+   
+-  <launchable type="desktop-id">quaternion.desktop</launchable>
++  <launchable type="desktop-id">com.github.quaternion.desktop</launchable>
+ 
+   <screenshots>
+     <screenshot type="default">

--- a/com.github.quaternion.json
+++ b/com.github.quaternion.json
@@ -34,6 +34,10 @@
                     "type": "git",
                     "url": "https://github.com/quotient-im/Quaternion.git",
                     "tag": "0.0.9.4f"
+                },
+                {
+                    "type": "patch",
+                    "path": "appdata.patch"
                 }
             ]
         }


### PR DESCRIPTION
This should fix the build error. Let's wait for the build before merging.

This is essentially the same as https://github.com/quotient-im/Quaternion/commit/1a53bf36e9a17c8aaead973b07ef6384dd98681e so nothing to do upstream.