### PR TITLE
Drop --own-name=org.kde.*

### DIFF
--- a/com.github.quaternion.yaml
+++ b/com.github.quaternion.yaml
@@ -17,7 +17,6 @@ finish-args:
 - --talk-name=org.kde.kwalletd5
 - --talk-name=org.freedesktop.Notifications
 - --talk-name=org.kde.StatusNotifierWatcher
-- --own-name=org.kde.*
 modules:
 - name: libolm
   buildsystem: cmake-ninja


### PR DESCRIPTION
They say it's fixed - let's see where it gets us.